### PR TITLE
Storage settings and CronJob

### DIFF
--- a/helm/gadgetron/templates/clusterrole.yaml
+++ b/helm/gadgetron/templates/clusterrole.yaml
@@ -8,4 +8,7 @@ metadata:
 rules:
 - apiGroups: [""] # "" indicates the core API group
   resources: ["services", "pods", "endpoints"]
-  verbs: ["get", "watch", "list"]
+  verbs: ["get", "watch", "list", "patch"]
+- apiGroups: ["autoscaling"]
+  resources: ["horizontalpodautoscalers"]
+  verbs: ["get", "watch", "list", "patch"]

--- a/helm/gadgetron/templates/horizontalpodautoscaler.yaml
+++ b/helm/gadgetron/templates/horizontalpodautoscaler.yaml
@@ -17,3 +17,50 @@ spec:
       target:
         type: AverageValue
         averageValue: {{ .Values.hpa.targetInstanceUtilization }}
+
+{{ if .Values.hpa.schedule }}
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: {{ include "gadgetron.fullname" . }}-up
+spec:
+  schedule: "{{ .Values.hpa.schedule.up.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hpa-scale
+            image: bitnami/kubectl:latest
+            command:
+            - kubectl 
+            - patch
+            - hpa
+            - {{ include "gadgetron.fullname" . }}
+            - -p
+            - '{"spec":{"minReplicas": {{ .Values.hpa.schedule.up.minReplicas }} }}'
+          restartPolicy: OnFailure
+---
+kind: CronJob
+apiVersion: batch/v1beta1
+metadata:
+  name: {{ include "gadgetron.fullname" . }}-down
+spec:
+  schedule: "{{ .Values.hpa.schedule.down.schedule }}"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hpa-scale
+            image: bitnami/kubectl:latest
+            command:
+            - kubectl 
+            - patch
+            - hpa
+            - {{ include "gadgetron.fullname" . }}
+            - -p
+            - '{"spec":{"minReplicas": {{ .Values.hpa.schedule.down.minReplicas }} }}'
+          restartPolicy: OnFailure
+{{ end }}

--- a/helm/gadgetron/templates/persistentvolumeclaim.yaml
+++ b/helm/gadgetron/templates/persistentvolumeclaim.yaml
@@ -10,7 +10,7 @@ spec:
   storageClassName: {{ .Values.storage.storageClass }}
   resources:
     requests:
-      storage: 5Gi
+      storage: {{ .Values.storage.dependenciesVolumeSize }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -24,4 +24,4 @@ spec:
   storageClassName: {{ .Values.storage.storageClass }}
   resources:
     requests:
-      storage: 5Gi
+      storage: {{ .Values.storage.dataVolumeSize }}

--- a/helm/gadgetron/values.yaml
+++ b/helm/gadgetron/values.yaml
@@ -33,6 +33,13 @@ hpa:
   minReplicas: 1
   maxReplicas: 20
   targetInstanceUtilization: 500m
+  schedule: {}
+    # up:
+    #   schedule: "0 7 * * 1-5"
+    #   minReplicas: 5
+    # down:
+    #   schedule: "0 18 * * 1-5"
+    #   minReplicas: 1
 
 resources:
   # limits:

--- a/helm/gadgetron/values.yaml
+++ b/helm/gadgetron/values.yaml
@@ -14,6 +14,8 @@ fullnameOverride: ""
 
 storage:
   storageClass: standard
+  dependenciesVolumeSize: 5Gi
+  dataVolumeSize: 100Gi
 
 service:
   type: ClusterIP


### PR DESCRIPTION
This PR:

* Exposes storage volume sizes as settings
* Optionally enables a CronJob to scale up and down.

To use:

```
storage:
  dataVolumeSize: 50Gi
  dependenciesVolumeSize: 10Gi
  storageClass: azurefile
hpa:
  minReplicas: 1
  maxReplicas: 20
  targetInstanceUtilization: 500m
  schedule:
    up:
      schedule: "00 07 * * 1-5"
      minReplicas: 5
    down:
      schedule: "00 18 * * 1-5"
      minReplicas: 1
resources:
  requests:
    cpu: 8000m
    memory: 8Gi
```

This would guarantee that each pod added has at least 8 cores and that between the hours of 0700 and 1800 (UTC) there would be a minimum of 5 replicas. 