### PR TITLE
Updated SSH jump server to import SSH server keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gadgetron-ssh-secret.yaml
+ssh_keys/

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ GTCLUSTERIP=$(kubectl get svc <gadgetron-frontend> --output=json | jq -r .spec.c
 ssh -L 9022:${GTCLUSTERIP}:9002 root@${EXTERNALIP}
 ```
 
+A simpler approach that should also work with most Kubernetes DNS schemes would be:
+
+```bash
+ssh -L 9022:<gadgetron-service-name>:9002 root@${EXTERNALIP}
+```
+
 ## Connecting with stunnel
 
 The repo contains a helm chart for deploying [stunnel](https://stunnel.org) for secure access to the Gadgetron in the cluster. To deploy the `stunnel` server, you must first have some secrets (pre-shared keys). You can generate those and store them as a secret in the cluster with:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This repo also contains a helm chart and other artifacts for deploying an SSH ju
 
 > Approach adopted from [https://github.com/kubernetes-contrib/jumpserver](https://github.com/kubernetes-contrib/jumpserver).
 
-First generate some keys for the SSH server. And store them in a Kubernetes secret. There is a script for doing this:
+First generate some keys for the SSH server and store them in a Kubernetes secret. There is a script for doing this:
 
 ```bash
 ./generate_ssh_keys.sh

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ First generate some keys for the SSH server and store them in a Kubernetes secre
 ./generate_ssh_keys.sh
 ```
 
-Then store the public for the user to connect, e.g.:
+Then store the public key for the user to connect, e.g.:
 
 ```bash
 kubectl create secret generic sshkey --from-file=authorizedkeys=/home/<myuser>/.ssh/id_rsa.pub 
 ```
 
-Replace the path the public key with the specific key that you would like to use. Before deploying the SSH jump server you should two secrets (check with `kubectl get keys`) in your cluster: `sshkey` and `ssh-server-keys`.
+Replace the the public key path with the specific key that you would like to use. Before deploying the SSH jump server you should have two secrets (check with `kubectl get secrets`) in your cluster: `sshkey` and `ssh-server-keys`.
 
 Then deploy the jump server:
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ First generate some keys for the SSH server and store them in a Kubernetes secre
 ./generate_ssh_keys.sh
 ```
 
+This script will by default generate RSA, ECDSA, and ED25519 keys. If you would like to restrict or expand the keys generated, add the desired algorithms as arguments, e.g.:
+
+```bash
+./generate_ssh_keys.sh rsa ed25519
+```
+
 Then store the public key for the user to connect, e.g.:
 
 ```bash

--- a/gadgetron-ssh-secret.yaml.tmpl
+++ b/gadgetron-ssh-secret.yaml.tmpl
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: sshkey
-type: Opaque
-data:
-  authorizedkeys: PUBLIC_KEY

--- a/generate_ssh_keys.sh
+++ b/generate_ssh_keys.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+mkdir -p ssh_keys
+rm -rf ssh_keys/*
+ssh-keygen -f ssh_keys/ssh_host_rsa_key -N '' -t rsa
+ssh-keygen -f ssh_keys/ssh_host_ed25519_key -N '' -t ed25519
+ssh-keygen -f ssh_keys/ssh_host_ecdsa_key -N '' -t ecdsa
+
+kubectl create secret generic ssh-server-keys \
+    --from-file=ssh_host_rsa_key=ssh_keys/ssh_host_rsa_key \
+    --from-file=ssh_host_rsa_key.pub=ssh_keys/ssh_host_rsa_key.pub \
+    --from-file=ssh_host_ed25519_key=ssh_keys/ssh_host_ed25519_key \
+    --from-file=ssh_host_ed25519_key.pub=ssh_keys/ssh_host_ed25519_key.pub \
+    --from-file=ssh_host_ecdsa_key=ssh_keys/ssh_host_ecdsa_key \
+    --from-file=ssh_host_ecdsa_key.pub=ssh_keys/ssh_host_ecdsa_key.pub
+

--- a/generate_ssh_keys.sh
+++ b/generate_ssh_keys.sh
@@ -1,16 +1,17 @@
 #!/bin/bash
 
+if [ $# -gt 0 ]; then
+    ALGORITHMS=$@
+else
+    ALGORITHMS="rsa ed25519 ecdsa"
+fi
+
 mkdir -p ssh_keys
 rm -rf ssh_keys/*
-ssh-keygen -f ssh_keys/ssh_host_rsa_key -N '' -t rsa
-ssh-keygen -f ssh_keys/ssh_host_ed25519_key -N '' -t ed25519
-ssh-keygen -f ssh_keys/ssh_host_ecdsa_key -N '' -t ecdsa
 
-kubectl create secret generic ssh-server-keys \
-    --from-file=ssh_host_rsa_key=ssh_keys/ssh_host_rsa_key \
-    --from-file=ssh_host_rsa_key.pub=ssh_keys/ssh_host_rsa_key.pub \
-    --from-file=ssh_host_ed25519_key=ssh_keys/ssh_host_ed25519_key \
-    --from-file=ssh_host_ed25519_key.pub=ssh_keys/ssh_host_ed25519_key.pub \
-    --from-file=ssh_host_ecdsa_key=ssh_keys/ssh_host_ecdsa_key \
-    --from-file=ssh_host_ecdsa_key.pub=ssh_keys/ssh_host_ecdsa_key.pub
+for algorithm in $ALGORITHMS; do
+    ssh-keygen -f ssh_keys/ssh_host_${algorithm}_key -N '' -t ${algorithm}
+done
+
+kubectl create secret generic ssh-server-keys --from-file=ssh_keys
 

--- a/helm/sshjump/Chart.yaml
+++ b/helm/sshjump/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 version: 0.1.0
-appVersion: latest
+appVersion: 20210618-3

--- a/helm/sshjump/Chart.yaml
+++ b/helm/sshjump/Chart.yaml
@@ -4,4 +4,4 @@ description: A Helm chart for Kubernetes
 
 type: application
 version: 0.1.0
-appVersion: 20210618-3
+appVersion: 20210621-1

--- a/helm/sshjump/templates/deployment.yaml
+++ b/helm/sshjump/templates/deployment.yaml
@@ -32,6 +32,15 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.sshKeySecret }}
                   key: authorizedkeys
+          volumeMounts:
+            - name: ssh-server-secrets
+              mountPath: /opt/ssh-server-secrets
+              readOnly: true
+      volumes:
+        - name: ssh-server-secrets
+          secret:
+            secretName: {{ .Values.sshServerKeysSecret }}
+            defaultMode: 0400
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/sshjump/values.yaml
+++ b/helm/sshjump/values.yaml
@@ -14,6 +14,7 @@ fullnameOverride: ""
 
 # Secret contained the authorized keys
 sshKeySecret: sshkey
+sshServerKeysSecret: ssh-server-keys
 
 service:
   type: LoadBalancer

--- a/ssh-jump-server/Dockerfile
+++ b/ssh-jump-server/Dockerfile
@@ -7,4 +7,5 @@ RUN apt-get update --quiet && \
 EXPOSE 22
 
 COPY entrypoint.sh /
+RUN chmod +x entrypoint.sh
 CMD ["/entrypoint.sh"]

--- a/ssh-jump-server/entrypoint.sh
+++ b/ssh-jump-server/entrypoint.sh
@@ -1,8 +1,17 @@
 #!/bin/bash
 
-#Set new keys
-rm -rf /etc/ssh/ssh_host_*
-dpkg-reconfigure openssh-server
+if [[ -f /opt/ssh-server-secrets/ssh_host_rsa_key ]]; then
+    # Keys have been mounted, copy them
+    cp /opt/ssh-server-secrets/* /etc/ssh/
+    chmod 644 /etc/ssh/*.pub
+    chmod 600 /etc/ssh/ssh_host_ecdsa_key
+    chmod 600 /etc/ssh/ssh_host_ed25519_key
+    chmod 600 /etc/ssh/ssh_host_rsa_key
+else
+    # Genenerate
+    rm -rf /etc/ssh/ssh_host_*
+    dpkg-reconfigure openssh-server
+fi
 
 #Switch off DNS checking
 sed -i.bak "s/#UseDNS no/UseDNS no/g" /etc/ssh/sshd_config

--- a/ssh-jump-server/entrypoint.sh
+++ b/ssh-jump-server/entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-if [[ -f /opt/ssh-server-secrets/ssh_host_rsa_key ]]; then
+if [[ -d /opt/ssh-server-secrets ]]; then
     # Keys have been mounted, copy them
     cp /opt/ssh-server-secrets/* /etc/ssh/
     chmod 644 /etc/ssh/*.pub
-    chmod 600 /etc/ssh/ssh_host_ecdsa_key
-    chmod 600 /etc/ssh/ssh_host_ed25519_key
-    chmod 600 /etc/ssh/ssh_host_rsa_key
+    for f in $(ls /etc/ssh/ssh_host_*_key); do
+        chmod 600 $f
+    done
 else
     # Genenerate
     rm -rf /etc/ssh/ssh_host_*


### PR DESCRIPTION
This PR:
* Provides a script to generate ssh server keys in a Kubernetes key
* Updates the SSH jump server to import the keys when available
* Updates SSH jump server helm chart to provide the server keys from a secret
* Updates README to provide instruction on key generation
* Updated README showing that gadgetron service name can be used instead of IP address for SSH tunnel
* Removes template for creating SSH secret, uses `kubectl create secret --from-file=sshsecret=<...>` instead