### PR TITLE
Resource specification for storage server

### DIFF
--- a/helm/gadgetron/templates/storageserverdeployment.yaml
+++ b/helm/gadgetron/templates/storageserverdeployment.yaml
@@ -39,7 +39,7 @@ spec:
             - mountPath: "/tmp/gadgetron"
               name: {{ include "gadgetron.dependenciesname" . }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.storage.storageServer.resources | nindent 12 }}
       volumes:
       - name: {{ include "gadgetron.dependenciesname" . }}
         persistentVolumeClaim:

--- a/helm/gadgetron/values.yaml
+++ b/helm/gadgetron/values.yaml
@@ -19,6 +19,13 @@ storage:
   storageServer:
     enable: true
     port: 9112
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 1024Mi
+      # limits:
+      #   cpu: 5000m
+      #   memory: 128Mi
 
 service:
   type: ClusterIP


### PR DESCRIPTION
This PR fixes a problem with resource specifications for the storage server. Previously the storage server deployment would use the resource specifications for the Gadgetron pods, e.g. if `resources.requests.cpu = 16000m`, it would allocate 16 cores for the storage server, which might scale up nodes unnecessarily. Resources for the storage server can now be specified with:

```yaml
storage:
  storageClass: azurefile
  dependenciesVolumeSize: 5Gi
  dataVolumeSize: 100Gi
  storageServer:
    enable: true
    port: 9112
    resources:
      requests:
        cpu: 1000m
        memory: 1024Mi
```