### PR TITLE
Setting ClientAliveInterval in SSH server

### DIFF
--- a/helm/sshjump/Chart.yaml
+++ b/helm/sshjump/Chart.yaml
@@ -3,5 +3,5 @@ name: sshjump
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.1.0
-appVersion: 20210621-1
+version: 0.1.1
+appVersion: 20210913-1

--- a/helm/sshjump/templates/deployment.yaml
+++ b/helm/sshjump/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.sshKeySecret }}
                   key: authorizedkeys
+            {{ if .Values.sshClientAliveInterval }}
+            - name: CLIENTALIVEINTERVAL
+              value: {{ .Values.sshClientAliveInterval | quote }}
+            {{ end }}
           volumeMounts:
             - name: ssh-server-secrets
               mountPath: /opt/ssh-server-secrets

--- a/helm/sshjump/values.yaml
+++ b/helm/sshjump/values.yaml
@@ -16,6 +16,9 @@ fullnameOverride: ""
 sshKeySecret: sshkey
 sshServerKeysSecret: ssh-server-keys
 
+# SSH server settings
+sshClientAliveInterval: 60
+
 service:
   type: LoadBalancer
   port: 22

--- a/ssh-jump-server/entrypoint.sh
+++ b/ssh-jump-server/entrypoint.sh
@@ -16,6 +16,10 @@ fi
 #Switch off DNS checking
 sed -i.bak "s/#UseDNS no/UseDNS no/g" /etc/ssh/sshd_config
 
+if [[ -n "${CLIENTALIVEINTERVAL}" ]]; then
+    sed -i.bak "s/#ClientAliveInterval 0/ClientAliveInterval ${CLIENTALIVEINTERVAL}/g" /etc/ssh/sshd_config
+fi
+
 #Import public key
 mkdir -p /root/.ssh
 touch /root/.ssh/authorized_keys


### PR DESCRIPTION
In order to prevent connection timeouts in cases where the connecting client cannot set `ServerAliveInterval`, we are now setting `ClientAliveInterval` on the ssh jump server. 